### PR TITLE
feat: store onboarding completion in settings

### DIFF
--- a/screenpipe-app-tauri/components/onboarding.tsx
+++ b/screenpipe-app-tauri/components/onboarding.tsx
@@ -1,4 +1,3 @@
-import localforage from "localforage";
 import React, { useState, useEffect } from "react";
 import { useToast } from "@/components/ui/use-toast";
 import OnboardingPipes from "@/components/onboarding/pipes";
@@ -12,7 +11,6 @@ import OnboardingDevConfig from "@/components/onboarding/dev-configuration";
 import OnboardingSelection from "@/components/onboarding/usecases-selection";
 import OnboardingInstructions from "@/components/onboarding/explain-instructions";
 import { useOnboarding } from "@/lib/hooks/use-onboarding";
-import { useSettings } from "@/lib/hooks/use-settings";
 import OnboardingLogin from "./onboarding/login";
 import OnboardingPipeStore from "./onboarding/pipe-store";
 import posthog from "posthog-js";

--- a/screenpipe-app-tauri/components/onboarding/introduction.tsx
+++ b/screenpipe-app-tauri/components/onboarding/introduction.tsx
@@ -3,7 +3,6 @@ import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { RainbowButton } from "../ui/rainbow-button";
 import { ArrowRight } from "lucide-react";
-import { useSettings } from "@/lib/hooks/use-settings";
 import posthog from "posthog-js";
 import { useOnboarding } from "@/lib/hooks/use-onboarding";
 

--- a/screenpipe-app-tauri/lib/hooks/use-onboarding.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-onboarding.tsx
@@ -1,59 +1,13 @@
 import { useSettings } from "./use-settings";
-import localforage from "localforage";
-import { create } from "zustand";
-import { useEffect } from "react";
 
-// Define the store state type
-interface OnboardingState {
-  showOnboarding: boolean;
-  setShowOnboarding: (show: boolean) => void;
-  initialized: boolean;
-}
-
-// Create the Zustand store
-export const useOnboardingStore = create<OnboardingState>((set) => ({
-  showOnboarding: false,
-  initialized: false,
-  setShowOnboarding: (show: boolean) => {
-    set({ showOnboarding: show });
-    localforage.setItem("showOnboarding", show);
-  },
-}));
-
-// Initialize the store with persisted data
-const initializeOnboarding = async () => {
-  // Only initialize once
-  if (useOnboardingStore.getState().initialized) {
-    return;
-  }
-
-  const persistedValue = await localforage.getItem("showOnboarding");
-
-  if (persistedValue === null || persistedValue === undefined) {
-    // First time user, show onboarding
-    useOnboardingStore.setState({
-      showOnboarding: true,
-      initialized: true,
-    });
-  } else {
-    // Returning user, respect the stored value
-    useOnboardingStore.setState({
-      showOnboarding: persistedValue === true,
-      initialized: true,
-    });
-  }
-};
-
-// Custom hook that combines store with initialization logic
 export const useOnboarding = () => {
-  const { showOnboarding, setShowOnboarding } = useOnboardingStore();
-  const { settings } = useSettings();
+  const { settings, updateSettings } = useSettings();
+  const showOnboarding = !settings.hasCompletedOnboarding;
 
-  useEffect(() => {
-    initializeOnboarding();
-  }, [settings]);
+  const setShowOnboarding = (show: boolean) => {
+    updateSettings({ hasCompletedOnboarding: !show });
+  };
 
   return { showOnboarding, setShowOnboarding };
 };
 
-// No longer need the OnboardingProvider component

--- a/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -112,8 +112,8 @@ export type Settings = {
 	useChineseMirror: boolean; // Add this line
 	embeddedLLM: EmbeddedLLMConfig;
 	languages: Language[];
-	enableBeta: boolean;
-	isFirstTimeUser: boolean;
+        enableBeta: boolean;
+        hasCompletedOnboarding: boolean;
 	autoStartEnabled: boolean;
 	enableFrameCache: boolean; // Add this line
 	enableUiMonitoring: boolean; // Add this line
@@ -182,8 +182,8 @@ const DEFAULT_SETTINGS: Settings = {
 		model: "llama3.2:1b-instruct-q4_K_M",
 		port: 11434,
 	},
-	enableBeta: false,
-	isFirstTimeUser: true,
+        enableBeta: false,
+        hasCompletedOnboarding: false,
 	autoStartEnabled: true,
 	enableFrameCache: true, // Add this line
 	enableUiMonitoring: false, // Change from true to false


### PR DESCRIPTION
## Summary
- add `hasCompletedOnboarding` flag to settings defaulting to false
- rework `useOnboarding` to persist completion via settings and drop zustand/localforage
- onboarding components consume settings-based hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: failed to copy screenpipe binary)*


------
https://chatgpt.com/codex/tasks/task_e_68a86583aeb8832286c318fd60d46ddb