### PR TITLE
feat(app): reset settings store on profile switch

### DIFF
--- a/screenpipe-app-tauri/app/page.tsx
+++ b/screenpipe-app-tauri/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getStore, useSettings } from "@/lib/hooks/use-settings";
+import { getStore, resetStore, useSettings } from "@/lib/hooks/use-settings";
 
 import React, { useEffect, useState } from "react";
 import NotificationHandler from "@/components/notification-handler";
@@ -114,6 +114,8 @@ export default function Home() {
       listen<string>("switch-profile", async (event) => {
         const profile = event.payload;
         setActiveProfile(profile);
+        resetStore();
+        await reloadStore();
 
         toast({
           title: "profile switched",

--- a/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -297,8 +297,12 @@ export const getStore = async () => {
 				autoSave: false,
 			});
 		})();
-	}
-	return storePromise;
+        }
+        return storePromise;
+};
+
+export const resetStore = () => {
+        storePromise = null;
 };
 
 const tauriStorage: PersistStorage = {


### PR DESCRIPTION
## Summary
- add resetStore utility to clear cached settings store
- reset and reload settings store when switching profiles before restart

## Testing
- `bun test` *(fails: Cannot find package 'desktop-use')*
- `bun tauri build` *(fails: command not found: tauri)*

------
https://chatgpt.com/codex/tasks/task_e_68a85b71bc748322bc50b194cd4d0b94