### PR TITLE
feat: deep merge settings updates

### DIFF
--- a/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -107,7 +107,6 @@ export function AccountSection() {
               if (settings.user) {
                 updateSettings({
                   user: {
-                    ...settings.user,
                     stripe_connected: true,
                   },
                 });
@@ -458,8 +457,7 @@ export function AccountSection() {
 
                         const { api_key } = await response.json();
                         if (settings.user) {
-                          const updatedUser = { ...settings.user, api_key };
-                          updateSettings({ user: updatedUser });
+                          updateSettings({ user: { api_key } });
                           toast({
                             title: "api key generated",
                             description: "you can now start building pipes",
@@ -566,11 +564,9 @@ export function AccountSection() {
                       className="h-9 w-9"
                       onClick={() => {
                         if (settings.user) {
-                          const updatedUser = {
-                            ...settings.user,
-                            stripe_connected: false,
-                          };
-                          updateSettings({ user: updatedUser });
+                          updateSettings({
+                            user: { stripe_connected: false },
+                          });
                           toast({
                             title: "stripe disconnected",
                             description:
@@ -708,11 +704,7 @@ export function AccountSection() {
 
                       // Update the main settings after successful profile update
                       if (settings.user) {
-                        const updatedUser = {
-                          ...settings.user,
-                          ...profileForm,
-                        };
-                        updateSettings({ user: updatedUser });
+                        updateSettings({ user: profileForm });
                       }
 
                       toast({

--- a/screenpipe-app-tauri/components/settings/shortcut-row.tsx
+++ b/screenpipe-app-tauri/components/settings/shortcut-row.tsx
@@ -161,7 +161,6 @@ const ShortcutRow = ({
           const pipeId = shortcut.replace("pipe_", "");
           updateSettings({
             pipeShortcuts: {
-              ...settings.pipeShortcuts,
               [pipeId]: keys,
             },
           });

--- a/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -15,6 +15,7 @@ import { flattenObject, unflattenObject } from "../utils";
 import { useEffect, useRef, useCallback } from "react";
 import posthog from "posthog-js";
 import localforage from "localforage";
+import merge from "lodash/merge";
 
 export type VadSensitivity = "low" | "medium" | "high";
 
@@ -355,11 +356,8 @@ export const store = createContextStore<StoreModel>(
                         isHydrated: false,
                         setSettings: action((state, payload) => {
                                 console.log(state, payload);
-                                state.settings = {
-                                        ...state.settings,
-                                        ...payload,
-				};
-			}),
+                                state.settings = merge({}, state.settings, payload);
+                        }),
 			resetSettings: action((state) => {
 				state.settings = createDefaultSettingsObject();
 			}),


### PR DESCRIPTION
## Summary
- use lodash merge in `setSettings` to preserve nested fields
- send only intended settings in deep link and profile handlers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a878d3a45c8322bdced21a673d124e